### PR TITLE
Limit slow tests terminal output to 10 entries

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -4,47 +4,82 @@
 version = "2.37.1"
 backend = "asdf:direnv"
 
-[[tools.just]]
-version = "1.49.0"
-backend = "ubi:casey/just"
+[[tools."github:casey/just"]]
+version = "1.57.0"
+backend = "github:casey/just"
+
+[tools."github:casey/just"."platforms.linux-arm64"]
+checksum = "sha256:f225044a81adea6e0b3a8b9370aaf374e6af76c8735ae263ac993df55fd137ec"
+url = "https://github.com/casey/just/releases/download/1.57.0/just-1.57.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/481976912"
+
+[tools."github:casey/just"."platforms.linux-arm64-musl"]
+checksum = "sha256:f225044a81adea6e0b3a8b9370aaf374e6af76c8735ae263ac993df55fd137ec"
+url = "https://github.com/casey/just/releases/download/1.57.0/just-1.57.0-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/481976912"
+
+[tools."github:casey/just"."platforms.linux-x64"]
+checksum = "sha256:45b548094283cb9739af8f13273b8cddeee869f5b4ef2bb631b1f311cb566155"
+url = "https://github.com/casey/just/releases/download/1.57.0/just-1.57.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/481976790"
+
+[tools."github:casey/just"."platforms.linux-x64-musl"]
+checksum = "sha256:45b548094283cb9739af8f13273b8cddeee869f5b4ef2bb631b1f311cb566155"
+url = "https://github.com/casey/just/releases/download/1.57.0/just-1.57.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/481976790"
+
+[tools."github:casey/just"."platforms.macos-arm64"]
+checksum = "sha256:0381db216c2f97ce31d838a1562c1064dfbfa73f5a8a81581338a2cd9217df47"
+url = "https://github.com/casey/just/releases/download/1.57.0/just-1.57.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/481976803"
+
+[tools."github:casey/just"."platforms.macos-x64"]
+checksum = "sha256:5e6ade3698095576274b2b32cc9e5d467185e8e40b04949004c04cc3d7e962dc"
+url = "https://github.com/casey/just/releases/download/1.57.0/just-1.57.0-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/481976824"
+
+[tools."github:casey/just"."platforms.windows-x64"]
+checksum = "sha256:4c7391d17cb1d17b758b52004ee6411372b8a13ff37c3c9b9031625cb6026e09"
+url = "https://github.com/casey/just/releases/download/1.57.0/just-1.57.0-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/casey/just/releases/assets/481977734"
 
 [[tools.python]]
 version = "3.14.4"
 backend = "core:python"
 
 [tools.python."platforms.linux-arm64"]
-checksum = "sha256:c84d61ae07e3b255f8bac6a28147bd373c3c1862d1d5598a9543a5b103fcb595"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260408/cpython-3.14.4+20260408-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:b8b597fdb2f8dccdc502c11947b60a4b65eb6bce79cfa60c7ccf9b6e8352c60a"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-arm64-musl"]
-checksum = "sha256:c84d61ae07e3b255f8bac6a28147bd373c3c1862d1d5598a9543a5b103fcb595"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260408/cpython-3.14.4+20260408-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:a10687b226e0941632569836bc1d8fa6353a8e3e8424316467ca9cdf220b983d"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-aarch64-unknown-linux-musl-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-x64"]
-checksum = "sha256:c838ac128a6e9c944b30301880472349eca8cd1abc79fb0d359ac2a358569389"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260408/cpython-3.14.4+20260408-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:fe9a9c32d13870af632cbac3dfc7528ae53597e94472aa4c7d6a42e8166136cd"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-x64-musl"]
-checksum = "sha256:c838ac128a6e9c944b30301880472349eca8cd1abc79fb0d359ac2a358569389"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260408/cpython-3.14.4+20260408-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:d6005226cd24e780630626232c7a63243d4885fdf975dcf930a0758a0759ce14"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-x86_64-unknown-linux-musl-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-arm64"]
-checksum = "sha256:f1ce5d79bceecbed25a37b611d6dae147b27857dda8181e3a5e29e73dd1c57c3"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260408/cpython-3.14.4+20260408-aarch64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:6f304f4ec30854611f23316578302235fb517cd970519ecdd11a8c4db87fd843"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-aarch64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-x64"]
-checksum = "sha256:1c9615f872058332b74b2be1b248078c636b6f4b116eed3e17f50eb7efe1a989"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260408/cpython-3.14.4+20260408-x86_64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:d51250a32fa5d9f0799c7bcb71720c27b10a3afd4a7de288120f96085d508a5a"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-x86_64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.windows-x64"]
-checksum = "sha256:472f4f0d91429661db1b28a72e36adc593b6bd5d19db222d7faca635b3005313"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260408/cpython-3.14.4+20260408-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
+checksum = "sha256:a976991dcd085c1bb5d9a8084823a6bc8b7f9b079d8c432574a6ddd68c3a6fe1"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [[tools.uv]]

--- a/structlog_config/pytest_plugin/__init__.py
+++ b/structlog_config/pytest_plugin/__init__.py
@@ -58,6 +58,7 @@ from .constants import (
     CAPTURE_PERSIST_ALL_KEY,
     CAPTURED_TESTS_KEY,
     PLUGIN_NAMESPACE,
+    SLOW_TESTS_DISPLAY_LIMIT,
     SLOW_THRESHOLD_KEY,
     SUBPROCESS_CAPTURE_ENV,
     logger,
@@ -281,6 +282,10 @@ def pytest_terminal_summary(terminalreporter, config: pytest.Config) -> None:
         slow_reports = _collect_slow_reports(terminalreporter, slow_threshold)
         if slow_reports:
             terminalreporter.write_sep("=", "slow tests")
-            for report in slow_reports:
+            for report in slow_reports[:SLOW_TESTS_DISPLAY_LIMIT]:
                 terminalreporter.write("[slow]", yellow=True)
                 terminalreporter.write_line(f" {report.duration:.2f}s {report.nodeid}")
+
+            hidden = len(slow_reports) - SLOW_TESTS_DISPLAY_LIMIT
+            if hidden > 0:
+                terminalreporter.write_line(f"{hidden} additional slow tests hidden")

--- a/structlog_config/pytest_plugin/constants.py
+++ b/structlog_config/pytest_plugin/constants.py
@@ -33,6 +33,9 @@ CAPTURED_TESTS_KEY = pytest.StashKey[list[CapturedTestFailure]]()
 SLOW_THRESHOLD_KEY = pytest.StashKey[float | None]()
 "Stash key for the slow test threshold in seconds; None means slow reporting is disabled."
 
+SLOW_TESTS_DISPLAY_LIMIT = 10
+"Max number of slow tests listed in the terminal summary before truncating."
+
 PLUGIN_NAMESPACE: str = "structlog_config"
 "Namespace used when registering options and artifact dirs with pytest-plugin-utils."
 

--- a/tests/pytest_plugin/test_terminal_summary.py
+++ b/tests/pytest_plugin/test_terminal_summary.py
@@ -245,6 +245,68 @@ def test_slow_tests_sorted_by_duration(pytester, plugin_conftest):
     assert slower_pos < faster_pos
 
 
+def test_slow_tests_output_limited_to_ten(pytester, plugin_conftest, monkeypatch):
+    """Slow section should list at most the display limit and note how many are hidden."""
+    monkeypatch.setattr(
+        "structlog_config.pytest_plugin.SLOW_TESTS_DISPLAY_LIMIT", 2
+    )
+    pytester.makeconftest(plugin_conftest)
+    pytester.makepyfile(
+        """
+        import time
+
+        def test_slow_0():
+            time.sleep(0.15)
+
+        def test_slow_1():
+            time.sleep(0.12)
+
+        def test_slow_2():
+            time.sleep(0.09)
+
+        def test_slow_3():
+            time.sleep(0.06)
+        """
+    )
+
+    result = pytester.runpytest("--slow-test-threshold=0.05")
+    assert result.ret == 0
+
+    output = result.stdout.str()
+    assert output.count("[slow]") == 2
+    assert "2 additional slow tests hidden" in output
+    assert "test_slow_0" in output
+    assert "test_slow_1" in output
+    assert "test_slow_2" not in output
+    assert "test_slow_3" not in output
+
+
+def test_slow_tests_no_hidden_message_at_limit(pytester, plugin_conftest, monkeypatch):
+    """Exactly display-limit slow tests should not show a hidden count."""
+    monkeypatch.setattr(
+        "structlog_config.pytest_plugin.SLOW_TESTS_DISPLAY_LIMIT", 2
+    )
+    pytester.makeconftest(plugin_conftest)
+    pytester.makepyfile(
+        """
+        import time
+
+        def test_slow_0():
+            time.sleep(0.1)
+
+        def test_slow_1():
+            time.sleep(0.1)
+        """
+    )
+
+    result = pytester.runpytest("--slow-test-threshold=0.05")
+    assert result.ret == 0
+
+    output = result.stdout.str()
+    assert output.count("[slow]") == 2
+    assert "additional slow tests hidden" not in output
+
+
 def test_no_color_suppresses_ansi_in_slow_output(
     pytester, plugin_conftest, monkeypatch
 ):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Cap the pytest plugin's `slow tests` terminal section at 10 entries (still sorted slowest-first)
- When more exist, print `X additional slow tests hidden`
- Fix CI: regenerate `mise.lock` so `github:casey/just` matches `mise.toml` (was still pinning `ubi:casey/just`, which broke `mise --locked` in matrix-test)

## Test plan
- [x] `pytest tests/pytest_plugin/test_terminal_summary.py`
- [x] Confirm matrix-test CI passes after lockfile fix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48477277-c5c6-4706-b299-e9afe9c75abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48477277-c5c6-4706-b299-e9afe9c75abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

