### PR TITLE
Include cached process PID in FastAPI access logs

### DIFF
--- a/structlog_config/fastapi_access_logger.py
+++ b/structlog_config/fastapi_access_logger.py
@@ -19,19 +19,9 @@ from starlette.websockets import WebSocket
 log = structlog.get_logger()
 ipware = FastAPIIpWare()
 
-# Cached once per process so access logs don't call getpid() on every request.
-# TODO PID is not a great identifier (it changes when a worker restarts). Replace
-# with uvicorn's native worker ID when https://github.com/encode/uvicorn/pull/2529 lands.
+# TODO PID is a poor worker identifier. Replace with uvicorn's native worker ID
+# when https://github.com/encode/uvicorn/pull/2529 lands.
 PROCESS_PID = os.getpid()
-
-
-def _refresh_process_pid() -> None:
-    global PROCESS_PID
-    PROCESS_PID = os.getpid()
-
-
-if hasattr(os, "register_at_fork"):
-    os.register_at_fork(after_in_child=_refresh_process_pid)
 
 
 def get_route_name(app: FastAPI, scope: Scope, prefix: str = "") -> str:

--- a/structlog_config/fastapi_access_logger.py
+++ b/structlog_config/fastapi_access_logger.py
@@ -2,6 +2,7 @@
 Requires fastapi and is not loaded by default since fastapi is not a default dependency.
 """
 
+import os
 from time import perf_counter
 from urllib.parse import quote
 
@@ -17,6 +18,20 @@ from starlette.websockets import WebSocket
 
 log = structlog.get_logger()
 ipware = FastAPIIpWare()
+
+# Cached once per process so access logs don't call getpid() on every request.
+# TODO PID is not a great identifier (it changes when a worker restarts). Replace
+# with uvicorn's native worker ID when https://github.com/encode/uvicorn/pull/2529 lands.
+PROCESS_PID = os.getpid()
+
+
+def _refresh_process_pid() -> None:
+    global PROCESS_PID
+    PROCESS_PID = os.getpid()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_refresh_process_pid)
 
 
 def get_route_name(app: FastAPI, scope: Scope, prefix: str = "") -> str:
@@ -132,6 +147,7 @@ def add_middleware(
                 query=scope["query_string"].decode(),
                 client_ip=client_ip_from_request(request),
                 route=route_name,
+                pid=PROCESS_PID,
             )
 
             # we have to duplicate the above logic since we want to reraise the exception
@@ -151,6 +167,7 @@ def add_middleware(
             query=scope["query_string"].decode(),
             client_ip=client_ip_from_request(request),
             route=route_name,
+            pid=PROCESS_PID,
         )
 
         return response

--- a/tests/test_fastapi_access_logger.py
+++ b/tests/test_fastapi_access_logger.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -10,6 +12,7 @@ from fastapi.testclient import TestClient
 
 from structlog_config import configure_logger
 from structlog_config.fastapi_access_logger import (
+    PROCESS_PID,
     add_middleware,
     client_ip_from_request,
     get_path_with_query_string,
@@ -79,6 +82,7 @@ def test_access_log_basic_request(client, capsys):
     assert "method=GET" in log_output
     assert "path=/" in log_output
     assert "status=200" in log_output
+    assert f"pid={os.getpid()}" in log_output
 
 
 def test_access_log_with_params(client, capsys):
@@ -136,6 +140,7 @@ def test_access_log_exception(test_app):
         assert call_args.kwargs["status"] == 500
         assert call_args.kwargs["method"] == "GET"
         assert call_args.kwargs["path"] == "/boom"
+        assert call_args.kwargs["pid"] == PROCESS_PID
 
 
 def test_access_log_static_assets(client, capsys):
@@ -151,6 +156,36 @@ def test_access_log_static_assets(client, capsys):
         # Verify debug was called instead of info
         mock_log.debug.assert_called_once()
         mock_log.info.assert_not_called()
+
+
+def test_access_log_pid_is_cached(client):
+    """PID is captured once per process, not looked up on every request."""
+    with (
+        mock.patch(
+            "structlog_config.fastapi_access_logger.os.getpid", return_value=99999
+        ) as mock_getpid,
+        mock.patch("structlog_config.fastapi_access_logger.log") as mock_log,
+    ):
+        response = client.get("/")
+
+    assert response.status_code == 200
+    mock_getpid.assert_not_called()
+    mock_log.info.assert_called_once()
+    assert mock_log.info.call_args.kwargs["pid"] == PROCESS_PID
+    assert mock_log.info.call_args.kwargs["pid"] == os.getpid()
+
+
+def test_refresh_process_pid_after_fork():
+    """Gunicorn --preload forks after import; refresh the cached PID in the child."""
+    import structlog_config.fastapi_access_logger as access_logger
+
+    original_pid = access_logger.PROCESS_PID
+    try:
+        with mock.patch.object(access_logger.os, "getpid", return_value=4242):
+            access_logger._refresh_process_pid()
+        assert access_logger.PROCESS_PID == 4242
+    finally:
+        access_logger.PROCESS_PID = original_pid
 
 
 def test_get_route_name(test_app):

--- a/tests/test_fastapi_access_logger.py
+++ b/tests/test_fastapi_access_logger.py
@@ -175,19 +175,6 @@ def test_access_log_pid_is_cached(client):
     assert mock_log.info.call_args.kwargs["pid"] == os.getpid()
 
 
-def test_refresh_process_pid_after_fork():
-    """Gunicorn --preload forks after import; refresh the cached PID in the child."""
-    import structlog_config.fastapi_access_logger as access_logger
-
-    original_pid = access_logger.PROCESS_PID
-    try:
-        with mock.patch.object(access_logger.os, "getpid", return_value=4242):
-            access_logger._refresh_process_pid()
-        assert access_logger.PROCESS_PID == 4242
-    finally:
-        access_logger.PROCESS_PID = original_pid
-
-
 def test_get_route_name(test_app):
     """Test the get_route_name function"""
     # Create a scope for a request to the root endpoint


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Capture `os.getpid()` once at import and include it as `pid` on every FastAPI access log line.

This is a temporary stand-in so multi-worker request logs can be correlated. PID is a weak identifier because it changes when a worker restarts. A TODO points at [uvicorn#2529](https://github.com/encode/uvicorn/pull/2529) to switch to a native worker ID if that lands.

## Testing
- Access log success and exception paths include `pid`
- Cached PID is reused per request (`getpid` is not called in the request path)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53011ddf-d0b6-487d-b16f-bb4d7224c324?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53011ddf-d0b6-487d-b16f-bb4d7224c324&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

